### PR TITLE
feat(model): add InventoryItem entity for inventory management

### DIFF
--- a/src/main/java/com/elara/app/inventory_service/model/InventoryItem.java
+++ b/src/main/java/com/elara/app/inventory_service/model/InventoryItem.java
@@ -1,0 +1,55 @@
+package com.elara.app.inventory_service.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity(name = "inventory_item")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InventoryItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "name", unique = true, nullable = false, length = 100)
+    private String name;
+
+    @Size(max = 200)
+    @Column(name = "description", length = 200)
+    private String description;
+
+    @NotNull
+    @Positive
+    @Column(name = "base_unit_of_measure_id", nullable = false)
+    private Long baseUnitOfMeasureId; // Relationship with Uom service
+
+    @NotNull
+    @DecimalMin(value = "0.0", inclusive = false)
+    @Digits(integer = 10, fraction = 2)
+    @Column(name = "standard_cost", nullable = false, precision = 12, scale = 2)
+    private BigDecimal standardCost;
+
+    @NotNull
+    @DecimalMin(value = "0.0", inclusive = false)
+    @Digits(integer = 10, fraction = 2)
+    @Column(name = "unit_per_purchase_uom", nullable = false, precision = 12, scale = 2)
+    private BigDecimal unitPerPurchaseUom;
+
+    @NotNull
+    @DecimalMin(value = "0.0", inclusive = false)
+    @Digits(integer = 10, fraction = 2)
+    @Column(name = "reorder_point_quantity", nullable = false, precision = 12, scale = 2)
+    private BigDecimal reorderPointQuantity;
+
+}


### PR DESCRIPTION
This pull request introduces a new entity class to the inventory service, establishing the core data model for inventory items. The class uses JPA annotations for persistence, validation constraints for data integrity, and Lombok for boilerplate reduction.

New inventory item entity:

* Added `InventoryItem` class in `src/main/java/com/elara/app/inventory_service/model/InventoryItem.java` with JPA entity mapping, including fields for `id`, `name`, `description`, `baseUnitOfMeasureId`, `standardCost`, `unitPerPurchaseUom`, and `reorderPointQuantity`.
* Applied validation constraints (e.g., `@NotBlank`, `@Size`, `@NotNull`, `@Positive`, `@DecimalMin`, `@Digits`) to ensure data integrity for key fields.
* Utilized Lombok annotations (`@Getter`, `@Setter`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`) to reduce boilerplate code.