### PR TITLE
Feature/inventory item mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<lombok.version>1.18.38</lombok.version>
         <postgresql.version>42.7.7</postgresql.version>
 		<h2.version>2.3.232</h2.version>
+		<mapstruct.version>1.6.3</mapstruct.version>
 	</properties>
 
 	<!-- - - - - - - - - - - - - -->
@@ -77,6 +78,11 @@
 			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
 
 		<!-- Runtime dependencies -->
 		<dependency>

--- a/src/main/java/com/elara/app/inventory_service/mapper/InventoryItemMapper.java
+++ b/src/main/java/com/elara/app/inventory_service/mapper/InventoryItemMapper.java
@@ -1,0 +1,21 @@
+package com.elara.app.inventory_service.mapper;
+
+import com.elara.app.inventory_service.dto.request.InventoryItemRequest;
+import com.elara.app.inventory_service.dto.response.InventoryItemResponse;
+import com.elara.app.inventory_service.dto.update.InventoryItemUpdate;
+import com.elara.app.inventory_service.model.InventoryItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface InventoryItemMapper {
+
+    InventoryItem toEntity(InventoryItemRequest request);
+
+    InventoryItemResponse toResponse(InventoryItem entity);
+
+    @Mapping(target = "id", ignore = true)
+    void updateEntityFromDto(@MappingTarget InventoryItem existing, InventoryItemUpdate update);
+
+}


### PR DESCRIPTION
This pull request introduces MapStruct to the project and adds a new mapper interface for inventory items. The main focus is on simplifying and standardizing the transformation between DTOs and entity models in the inventory service.

**Dependency management and mapper introduction:**

* Added the MapStruct version property (`mapstruct.version`) to the Maven properties section in `pom.xml`, enabling version management for MapStruct.
* Added MapStruct as a compile-time dependency in `pom.xml`, allowing the use of MapStruct for automatic mapping between Java beans.

**Inventory item mapping:**

* Created a new mapper interface `InventoryItemMapper` in `src/main/java/com/elara/app/inventory_service/mapper/InventoryItemMapper.java` using MapStruct, which provides methods for converting between `InventoryItemRequest`, `InventoryItemResponse`, `InventoryItemUpdate`, and `InventoryItem` entities, and supports updating existing entities from DTOs.