### PR TITLE
Feature/inventory item service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <postgresql.version>42.7.7</postgresql.version>
 		<h2.version>2.3.232</h2.version>
 		<mapstruct.version>1.6.3</mapstruct.version>
+		<mapstruct.processor.version>1.6.3</mapstruct.processor.version>
 	</properties>
 
 	<!-- - - - - - - - - - - - - -->
@@ -83,6 +84,12 @@
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
+		<dependency>
+    		<groupId>org.mapstruct</groupId>
+    		<artifactId>mapstruct-processor</artifactId>
+			<version>${mapstruct.processor.version}</version>
+    		<scope>provided</scope>
+		</dependency>
 
 		<!-- Runtime dependencies -->
 		<dependency>

--- a/src/main/java/com/elara/app/inventory_service/config/AppConfig.java
+++ b/src/main/java/com/elara/app/inventory_service/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.elara.app.inventory_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/elara/app/inventory_service/dto/response/InventoryItemResponse.java
+++ b/src/main/java/com/elara/app/inventory_service/dto/response/InventoryItemResponse.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 public record InventoryItemResponse(
 
+    Long id,
     String name,
     String description,
     Long baseUnitOfMeasureId,

--- a/src/main/java/com/elara/app/inventory_service/dto/response/UomResponse.java
+++ b/src/main/java/com/elara/app/inventory_service/dto/response/UomResponse.java
@@ -1,0 +1,14 @@
+package com.elara.app.inventory_service.dto.response;
+
+import java.math.BigDecimal;
+
+public record UomResponse(
+
+    Long id,
+    String name,
+    String description,
+    BigDecimal conversionFactorToBase,
+    Long uomStatusId
+
+) {
+}

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -3,7 +3,11 @@ package com.elara.app.inventory_service.service.imp;
 import com.elara.app.inventory_service.dto.request.InventoryItemRequest;
 import com.elara.app.inventory_service.dto.response.InventoryItemResponse;
 import com.elara.app.inventory_service.dto.update.InventoryItemUpdate;
+import com.elara.app.inventory_service.mapper.InventoryItemMapper;
+import com.elara.app.inventory_service.repository.InventoryItemRepository;
 import com.elara.app.inventory_service.service.interfaces.InventoryItemService;
+import com.elara.app.inventory_service.utils.MessageService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -14,17 +18,26 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class InventoryItemImp implements InventoryItemService {
+
+    private static final String ENTITY_NAME = "Inventory Item";
+    private final InventoryItemMapper mapper;
+    private final InventoryItemRepository repository;
+    private final MessageService messageService;
+
     @Override
+    @Transactional
     public InventoryItemResponse save(InventoryItemRequest request) {
         return null;
     }
 
     @Override
+    @Transactional
     public InventoryItemResponse update(Long id, InventoryItemUpdate update) {
         return null;
     }
 
     @Override
+    @Transactional
     public void deleteById(Long id) {
 
     }

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -1,0 +1,51 @@
+package com.elara.app.inventory_service.service.imp;
+
+import com.elara.app.inventory_service.dto.request.InventoryItemRequest;
+import com.elara.app.inventory_service.dto.response.InventoryItemResponse;
+import com.elara.app.inventory_service.dto.update.InventoryItemUpdate;
+import com.elara.app.inventory_service.service.interfaces.InventoryItemService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InventoryItemImp implements InventoryItemService {
+    @Override
+    public InventoryItemResponse save(InventoryItemRequest request) {
+        return null;
+    }
+
+    @Override
+    public InventoryItemResponse update(Long id, InventoryItemUpdate update) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+
+    }
+
+    @Override
+    public InventoryItemResponse findById(Long id) {
+        return null;
+    }
+
+    @Override
+    public Page<InventoryItemResponse> findAll(Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<InventoryItemResponse> findAllByName(String name, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Boolean isNameTaken(String name) {
+        return null;
+    }
+}

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -3,16 +3,22 @@ package com.elara.app.inventory_service.service.imp;
 import com.elara.app.inventory_service.dto.request.InventoryItemRequest;
 import com.elara.app.inventory_service.dto.response.InventoryItemResponse;
 import com.elara.app.inventory_service.dto.update.InventoryItemUpdate;
+import com.elara.app.inventory_service.exceptions.ResourceConflictException;
+import com.elara.app.inventory_service.exceptions.ResourceNotFoundException;
 import com.elara.app.inventory_service.mapper.InventoryItemMapper;
+import com.elara.app.inventory_service.model.InventoryItem;
 import com.elara.app.inventory_service.repository.InventoryItemRepository;
 import com.elara.app.inventory_service.service.interfaces.InventoryItemService;
 import com.elara.app.inventory_service.utils.MessageService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -20,13 +26,36 @@ import org.springframework.stereotype.Service;
 public class InventoryItemImp implements InventoryItemService {
 
     private static final String ENTITY_NAME = "Inventory Item";
+    private static final String nomenclature = "InventoryItem-service";
     private final InventoryItemMapper mapper;
     private final InventoryItemRepository repository;
     private final MessageService messageService;
+    private final UomServiceClient uomServiceClient;
 
     @Override
     @Transactional
     public InventoryItemResponse save(InventoryItemRequest request) {
+        try {
+            log.debug("[" + nomenclature + "-save] Attempting to create {} with name: {} and request: {}", ENTITY_NAME, request != null ? request.name() : null, request);
+            if (Boolean.TRUE.equals(isNameTaken(Objects.requireNonNull(request).name()))) {
+                String msg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
+                log.warn("[" + nomenclature + "-save] {}", msg);
+                throw new ResourceConflictException(new Object[]{"name", request.name()});
+            }
+            uomServiceClient.verifyUomById(request.baseUnitOfMeasureId());
+            InventoryItem entity = mapper.toEntity(request);
+            log.debug("[" + nomenclature + "save] Mapped DTO to entity: {}", entity);
+            InventoryItem saved = repository.save(entity);
+            log.debug("[" + nomenclature + "save] {}", messageService.getMessage("crud.create.success", ENTITY_NAME));
+            return mapper.toResponse(saved);
+        } catch (ResourceConflictException | ResourceNotFoundException e) {
+            throw e;
+        } catch (DataIntegrityViolationException e) {
+            log.error("[" + nomenclature + "-save] Data integrity violation while saving {}: {}", ENTITY_NAME, e.getMessage());
+            throw new ResourceConflictException(e.getMessage());
+        } catch (Exception e) {
+            log.error("[" + nomenclature + "-save] Unexpected error while saving: {}: {}", ENTITY_NAME, e.getMessage(), e);
+        }
         return null;
     }
 
@@ -59,6 +88,9 @@ public class InventoryItemImp implements InventoryItemService {
 
     @Override
     public Boolean isNameTaken(String name) {
-        return null;
+        log.debug("[" + nomenclature + "-isNameTaken] checking if name '{}' is taken for {}", name, ENTITY_NAME);
+        Boolean exists = repository.existsByNameIgnoreCase(name);
+        log.debug("[" + nomenclature + "-isNameTaken] Name '{}' taken: {}", name, exists);
+        return exists;
     }
 }

--- a/src/main/java/com/elara/app/inventory_service/service/imp/UomServiceClient.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/UomServiceClient.java
@@ -1,0 +1,38 @@
+package com.elara.app.inventory_service.service.imp;
+
+import com.elara.app.inventory_service.dto.response.UomResponse;
+import com.elara.app.inventory_service.exceptions.ResourceNotFoundException;
+import com.elara.app.inventory_service.utils.MessageService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class UomServiceClient {
+
+    private static final String nomenclature = "Uom-service";
+    private static final String ENTITY_NAME = "Uom";
+    private final RestTemplate restTemplate;
+    private final String uomServiceBaseUrl = "http://localhost:8080/api/v1/uom/";
+    private final MessageService messageService;
+
+    public UomServiceClient(RestTemplate restTemplate, MessageService messageService) {
+        this.restTemplate = restTemplate;
+        this.messageService = messageService;
+    }
+
+    public void verifyUomById(Long id) {
+        try {
+            log.debug("[" + nomenclature + "-findById] Searching {} with id: {}", ENTITY_NAME, id);
+            restTemplate.getForObject(uomServiceBaseUrl + id, UomResponse.class);
+            log.debug("[Uom-service-findById] {}", messageService.getMessage("crud.read.success", ENTITY_NAME));
+        } catch (HttpClientErrorException.NotFound e) {
+            String msg = messageService.getMessage("crud.not.found", "UOM", "id", id.toString());
+            log.warn("[" + nomenclature + "-findById] {}", msg);
+            throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
+        }
+    }
+
+}

--- a/src/main/java/com/elara/app/inventory_service/service/interfaces/InventoryItemService.java
+++ b/src/main/java/com/elara/app/inventory_service/service/interfaces/InventoryItemService.java
@@ -1,0 +1,25 @@
+package com.elara.app.inventory_service.service.interfaces;
+
+import com.elara.app.inventory_service.dto.request.InventoryItemRequest;
+import com.elara.app.inventory_service.dto.response.InventoryItemResponse;
+import com.elara.app.inventory_service.dto.update.InventoryItemUpdate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface InventoryItemService {
+
+    InventoryItemResponse save(InventoryItemRequest request);
+
+    InventoryItemResponse update(Long id, InventoryItemUpdate update);
+
+    void deleteById(Long id);
+
+    InventoryItemResponse findById(Long id);
+
+    Page<InventoryItemResponse> findAll(Pageable pageable);
+
+    Page<InventoryItemResponse> findAllByName(String name, Pageable pageable);
+
+    Boolean isNameTaken(String name);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8081
 spring:
   application:
     name: inventory-service


### PR DESCRIPTION
This pull request introduces several foundational changes to the inventory service, focusing on enabling communication with an external UOM (Unit of Measure) service, implementing the core inventory item service logic, and improving DTOs and configuration. The most significant updates are the addition of service implementations, DTOs, and configuration for REST communication.

**Service Implementation and Integration:**

* Added `InventoryItemImp` class implementing the `InventoryItemService` interface, providing logic for saving inventory items, including name uniqueness checks and verification of UOM via an external service.
* Added `UomServiceClient` service to communicate with the UOM service using `RestTemplate`, including error handling for missing UOMs.

**DTO and Interface Enhancements:**

* Introduced `UomResponse` DTO for representing UOM data, and updated `InventoryItemResponse` to include an `id` field. [[1]](diffhunk://#diff-d7f10cb69eb6e67b99cbb0adeab99e2605d77a3d4cec0c62f56feff1704a4fc2R1-R14) [[2]](diffhunk://#diff-a398c451c8e76800993b5d4ecdbf6333908ab3e8f81f6b6e3d926c128f31f88aR7)
* Created the `InventoryItemService` interface, defining the contract for inventory item operations.

**Configuration and Dependency Updates:**

* Added `AppConfig` class to provide a `RestTemplate` bean for RESTful service communication.
* Updated `pom.xml` to include `mapstruct-processor` as a provided dependency for annotation processing. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R58) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R86-R91)
* Set the server port to `8081` in `application.yml` for the inventory service.