### PR TITLE
Feature/inventory item save endpoint controller

### DIFF
--- a/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
+++ b/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
@@ -1,9 +1,17 @@
 package com.elara.app.inventory_service.controller;
 
+import com.elara.app.inventory_service.dto.request.InventoryItemRequest;
+import com.elara.app.inventory_service.dto.response.InventoryItemResponse;
+import com.elara.app.inventory_service.service.interfaces.InventoryItemService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,4 +22,22 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 // @Tag(
 public class InventoryItemController {
+
+    private final InventoryItemService service;
+    private static final String NOMENCLATURE = "InventoryItem-controller";
+
+    // ========================================
+    // CREATE OPERATIONS
+    // ========================================
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<InventoryItemResponse> create(
+        @Valid @RequestBody InventoryItemRequest request
+    ) {
+        log.info("[" + NOMENCLATURE + "-create] Request to create InventoryItem: {}", request);
+        InventoryItemResponse response = service.save(request);
+        log.info("[" + NOMENCLATURE + "-create] InventoryItem created with id: {}", response.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
 }

--- a/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
+++ b/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
@@ -1,0 +1,17 @@
+package com.elara.app.inventory_service.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/v1/inventory-item", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+// @Tag(
+public class InventoryItemController {
+}

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 public class InventoryItemImp implements InventoryItemService {
 
     private static final String ENTITY_NAME = "Inventory Item";
-    private static final String nomenclature = "InventoryItem-service";
+    private static final String NOMENCLATURE = "InventoryItem-service";
     private final InventoryItemMapper mapper;
     private final InventoryItemRepository repository;
     private final MessageService messageService;
@@ -36,25 +36,25 @@ public class InventoryItemImp implements InventoryItemService {
     @Transactional
     public InventoryItemResponse save(InventoryItemRequest request) {
         try {
-            log.debug("[" + nomenclature + "-save] Attempting to create {} with name: {} and request: {}", ENTITY_NAME, request != null ? request.name() : null, request);
+            log.debug("[" + NOMENCLATURE + "-save] Attempting to create {} with name: {} and request: {}", ENTITY_NAME, request != null ? request.name() : null, request);
             if (Boolean.TRUE.equals(isNameTaken(Objects.requireNonNull(request).name()))) {
                 String msg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
-                log.warn("[" + nomenclature + "-save] {}", msg);
+                log.warn("[" + NOMENCLATURE + "-save] {}", msg);
                 throw new ResourceConflictException(new Object[]{"name", request.name()});
             }
             uomServiceClient.verifyUomById(request.baseUnitOfMeasureId());
             InventoryItem entity = mapper.toEntity(request);
-            log.debug("[" + nomenclature + "save] Mapped DTO to entity: {}", entity);
+            log.debug("[" + NOMENCLATURE + "save] Mapped DTO to entity: {}", entity);
             InventoryItem saved = repository.save(entity);
-            log.debug("[" + nomenclature + "save] {}", messageService.getMessage("crud.create.success", ENTITY_NAME));
+            log.debug("[" + NOMENCLATURE + "save] {}", messageService.getMessage("crud.create.success", ENTITY_NAME));
             return mapper.toResponse(saved);
         } catch (ResourceConflictException | ResourceNotFoundException e) {
             throw e;
         } catch (DataIntegrityViolationException e) {
-            log.error("[" + nomenclature + "-save] Data integrity violation while saving {}: {}", ENTITY_NAME, e.getMessage());
+            log.error("[" + NOMENCLATURE + "-save] Data integrity violation while saving {}: {}", ENTITY_NAME, e.getMessage());
             throw new ResourceConflictException(e.getMessage());
         } catch (Exception e) {
-            log.error("[" + nomenclature + "-save] Unexpected error while saving: {}: {}", ENTITY_NAME, e.getMessage(), e);
+            log.error("[" + NOMENCLATURE + "-save] Unexpected error while saving: {}: {}", ENTITY_NAME, e.getMessage(), e);
         }
         return null;
     }
@@ -88,9 +88,9 @@ public class InventoryItemImp implements InventoryItemService {
 
     @Override
     public Boolean isNameTaken(String name) {
-        log.debug("[" + nomenclature + "-isNameTaken] checking if name '{}' is taken for {}", name, ENTITY_NAME);
+        log.debug("[" + NOMENCLATURE + "-isNameTaken] checking if name '{}' is taken for {}", name, ENTITY_NAME);
         Boolean exists = repository.existsByNameIgnoreCase(name);
-        log.debug("[" + nomenclature + "-isNameTaken] Name '{}' taken: {}", name, exists);
+        log.debug("[" + NOMENCLATURE + "-isNameTaken] Name '{}' taken: {}", name, exists);
         return exists;
     }
 }

--- a/src/main/java/com/elara/app/inventory_service/service/imp/UomServiceClient.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/UomServiceClient.java
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class UomServiceClient {
 
-    private static final String nomenclature = "Uom-service";
+    private static final String NOMENCLATURE = "Uom-service";
     private static final String ENTITY_NAME = "Uom";
     private final RestTemplate restTemplate;
     private final String uomServiceBaseUrl = "http://localhost:8080/api/v1/uom/";
@@ -25,12 +25,12 @@ public class UomServiceClient {
 
     public void verifyUomById(Long id) {
         try {
-            log.debug("[" + nomenclature + "-findById] Searching {} with id: {}", ENTITY_NAME, id);
+            log.debug("[" + NOMENCLATURE + "-findById] Searching {} with id: {}", ENTITY_NAME, id);
             restTemplate.getForObject(uomServiceBaseUrl + id, UomResponse.class);
             log.debug("[Uom-service-findById] {}", messageService.getMessage("crud.read.success", ENTITY_NAME));
         } catch (HttpClientErrorException.NotFound e) {
             String msg = messageService.getMessage("crud.not.found", "UOM", "id", id.toString());
-            log.warn("[" + nomenclature + "-findById] {}", msg);
+            log.warn("[" + NOMENCLATURE + "-findById] {}", msg);
             throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
         }
     }


### PR DESCRIPTION
This pull request introduces a new REST controller for inventory items and standardizes logging nomenclature across service classes for improved consistency and traceability. The most significant changes are the addition of the `InventoryItemController` and the replacement of the `nomenclature` variable with the constant `NOMENCLATURE` in service classes, ensuring uniform log formatting.

### New Feature: Inventory Item Controller

* Added the `InventoryItemController` class, which exposes a POST endpoint at `/api/v1/inventory-item` for creating inventory items. It handles request validation, delegates creation to the service layer, and provides structured logging for incoming requests and responses.

### Logging Consistency Improvements

* Replaced all instances of the `nomenclature` variable with the constant `NOMENCLATURE` in `InventoryItemImp` and `UomServiceClient` to standardize log message formatting. [[1]](diffhunk://#diff-25a33a809d0f574c590cc4ebecfa2086efe01aed32da5695c166888e529a9da5L29-R29) [[2]](diffhunk://#diff-1641239cbd6eccd75cc68bdeecf87c25595bc881c93135d90acfa1d1f955040fL15-R15)
* Updated all log statements in `InventoryItemImp` to use the new `NOMENCLATURE` constant, ensuring consistent log prefixes for create and validation operations. [[1]](diffhunk://#diff-25a33a809d0f574c590cc4ebecfa2086efe01aed32da5695c166888e529a9da5L39-R57) [[2]](diffhunk://#diff-25a33a809d0f574c590cc4ebecfa2086efe01aed32da5695c166888e529a9da5L91-R93)
* Updated all log statements in `UomServiceClient` to use the new `NOMENCLATURE` constant for uniformity in service logs, especially in UOM verification and error handling.