### PR TITLE
Feature/refactor nomenclature names

### DIFF
--- a/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
+++ b/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
@@ -33,9 +33,10 @@ public class InventoryItemController {
     public ResponseEntity<InventoryItemResponse> create(
         @Valid @RequestBody InventoryItemRequest request
     ) {
-        log.info("[" + NOMENCLATURE + "-create] Request to create InventoryItem: {}", request);
+        final String methodNomenclature = NOMENCLATURE + "-create";
+        log.info("[{}] Request to create InventoryItem: {}", methodNomenclature, request);
         InventoryItemResponse response = service.save(request);
-        log.info("[" + NOMENCLATURE + "-create] InventoryItem created with id: {}", response.id());
+        log.info("[{}] InventoryItem created with id: {}", methodNomenclature, response.id());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -99,9 +99,10 @@ public class InventoryItemImp implements InventoryItemService {
 
     @Override
     public Boolean isNameTaken(String name) {
-        log.debug("[" + NOMENCLATURE + "-isNameTaken] checking if name '{}' is taken for {}", name, ENTITY_NAME);
+        String methodNomenclature = NOMENCLATURE + "-isNameTaken";
+        log.debug("[{}] checking if name '{}' is taken for {}", methodNomenclature, name, ENTITY_NAME);
         Boolean exists = repository.existsByNameIgnoreCase(name);
-        log.debug("[" + NOMENCLATURE + "-isNameTaken] Name '{}' taken: {}", name, exists);
+        log.debug("[{}] Name '{}' taken: {}", methodNomenclature, name, exists);
         return exists;
     }
 }

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -36,11 +36,12 @@ public class InventoryItemImp implements InventoryItemService {
     @Override
     @Transactional
     public InventoryItemResponse save(InventoryItemRequest request) {
+        final String methodNomenclature = NOMENCLATURE + "-save";
         try {
-            log.debug("[" + NOMENCLATURE + "-save] Attempting to create {} with name: {} and request: {}", ENTITY_NAME, request != null ? request.name() : null, request);
+            log.debug("[{}] Attempting to create {} with name: {} and request: {}", methodNomenclature, ENTITY_NAME, request != null ? request.name() : null, request);
             if (Boolean.TRUE.equals(isNameTaken(Objects.requireNonNull(request).name()))) {
                 String msg = messageService.getMessage("crud.already.exists", ENTITY_NAME, "name", request.name());
-                log.warn("[" + NOMENCLATURE + "-save] {}", msg);
+                log.warn("[{}] {}", methodNomenclature, msg);
                 throw new ResourceConflictException(new Object[]{"name", request.name()});
             }
             uomServiceClient.verifyUomById(request.baseUnitOfMeasureId());
@@ -52,10 +53,10 @@ public class InventoryItemImp implements InventoryItemService {
         } catch (ResourceConflictException | ResourceNotFoundException e) {
             throw e;
         } catch (DataIntegrityViolationException e) {
-            log.error("[" + NOMENCLATURE + "-save] Data integrity violation while saving {}: {}", ENTITY_NAME, e.getMessage());
+            log.error("[{}] Data integrity violation while saving {}: {}", methodNomenclature, ENTITY_NAME, e.getMessage());
             throw new ResourceConflictException(e.getMessage());
         } catch (Exception e) {
-            log.error("[" + NOMENCLATURE + "-save] Unexpected error while saving: {}: {}", ENTITY_NAME, e.getMessage(), e);
+            log.error("[{}] Unexpected error while saving: {}: {}", methodNomenclature, ENTITY_NAME, e.getMessage(), e);
         }
         return null;
     }


### PR DESCRIPTION
This pull request refactors logging statements in the inventory item controller and service classes to improve log consistency and clarity. The main change is the introduction of a local `methodNomenclature` variable, which is used in all log messages to better identify the method and operation being performed.

**Logging improvements:**

* All log statements in `InventoryItemController` and `InventoryItemImp` now use a local `methodNomenclature` variable for consistent method identification, replacing direct string concatenation with `NOMENCLATURE`. [[1]](diffhunk://#diff-44a4f79177ae65a86c91aaa987e12201dd7c5920f41be4fab167c9379d4c09e3L36-R39) [[2]](diffhunk://#diff-25a33a809d0f574c590cc4ebecfa2086efe01aed32da5695c166888e529a9da5R39-R44) [[3]](diffhunk://#diff-25a33a809d0f574c590cc4ebecfa2086efe01aed32da5695c166888e529a9da5L102-R106)
* Error and debug logs in `InventoryItemImp.save` now use the local `methodNomenclature` variable, making it easier to trace issues to specific methods.
* The `isNameTaken` method in `InventoryItemImp` was updated to use the local nomenclature variable in both debug statements, improving log readability and traceability.