### PR TITLE
Feature/get all endpoint controller

### DIFF
--- a/src/main/java/com/elara/app/inventory_service/InventoryServiceApplication.java
+++ b/src/main/java/com/elara/app/inventory_service/InventoryServiceApplication.java
@@ -2,8 +2,10 @@ package com.elara.app.inventory_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class InventoryServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
+++ b/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
@@ -8,6 +8,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -52,6 +55,17 @@ public class InventoryItemController {
         log.info("[{}] Request to get InventoryItem by id: {}", methodNomenclature, id);
         InventoryItemResponse response = service.findById(id);
         log.info("[{}] InventoryItem found: {}", methodNomenclature, response);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<InventoryItemResponse>> getAll(
+        @PageableDefault(size = 20, sort = "name") Pageable pageable
+    ) {
+        final String methodNomenclature = NOMENCLATURE + "-getAll";
+        log.info("[{}] Request to get all InventoryItems.", methodNomenclature);
+        Page<InventoryItemResponse> response = service.findAll(pageable);
+        log.info("[{}] Fetched {} InventoryItems.", methodNomenclature, response.getNumberOfElements());
         return ResponseEntity.ok(response);
     }
 


### PR DESCRIPTION
This pull request introduces support for paginated retrieval of inventory items in the inventory service. The main changes are the addition of a paginated endpoint in the `InventoryItemController` and the necessary configuration to enable Spring Data pagination features.

**Pagination support:**

* Added the `getAll` endpoint to `InventoryItemController`, allowing clients to fetch inventory items in a paginated manner using the `Pageable` interface. The endpoint defaults to a page size of 20 and sorts by `name`.
* Imported `Page`, `Pageable`, and `PageableDefault` in `InventoryItemController` to support pagination parameters in request handling.

**Spring Data configuration:**

* Enabled Spring Data Web support in `InventoryServiceApplication` by adding the `@EnableSpringDataWebSupport` annotation with `PageSerializationMode.VIA_DTO`, ensuring proper serialization of paginated responses.