### PR TITLE
Feature/delete endpoint

### DIFF
--- a/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
+++ b/src/main/java/com/elara/app/inventory_service/controller/InventoryItemController.java
@@ -110,4 +110,19 @@ public class InventoryItemController {
         return ResponseEntity.ok(response);
     }
 
+    // ========================================
+    // DELETE OPERATIONS
+    // ========================================
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+        @PathVariable @NotNull @Positive Long id
+    ) {
+        final String methodNomenclature = NOMENCLATURE + "-update";
+        log.info("[{}] Request to delete Uom id: {}", methodNomenclature, id);
+        service.deleteById(id);
+        log.info("[{}] Uom deleted: {}", methodNomenclature, id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/InventoryItemImp.java
@@ -99,7 +99,27 @@ public class InventoryItemImp implements InventoryItemService {
     @Override
     @Transactional
     public void deleteById(Long id) {
-        // Implement delete
+        String methodNomenclature = NOMENCLATURE + "-deleteById";
+        try {
+            log.debug("[{}] Attempting to delete {} with id: {}", methodNomenclature, ENTITY_NAME, id);
+            if (!repository.existsById(id)) {
+                String msg = messageService.getMessage("crud.not.found", ENTITY_NAME, "id", id.toString());
+                log.warn("[{}] {}", methodNomenclature, msg);
+                throw new ResourceNotFoundException(new Object[]{"id", id.toString()});
+            }
+            repository.deleteById(id);
+            String msg = messageService.getMessage("crud.delete.success", ENTITY_NAME);
+            log.debug("[{}] {}", methodNomenclature, msg);
+        } catch (ResourceNotFoundException | ResourceConflictException e) {
+            throw e;
+        } catch (DataIntegrityViolationException e) {
+            String msg = messageService.getMessage("repository.delete.error", ENTITY_NAME, e.getMessage());
+            log.error("[{}] {}", methodNomenclature, msg);
+            throw new UnexpectedErrorException(e.getMessage());
+        } catch (Exception e) {
+            log.error("[{}] Unexpected error while deleting {}: {}", methodNomenclature, ENTITY_NAME, e.getMessage(), e);
+            throw new UnexpectedErrorException(e.getMessage());
+        }
     }
 
     @Override


### PR DESCRIPTION
This pull request adds support for deleting inventory items through the API, including a new endpoint and robust error handling in the service layer. The most important changes are grouped below:

**API Enhancements:**

* Added a new `DELETE /{id}` endpoint to `InventoryItemController`, allowing inventory items to be deleted by ID.

**Service Layer Improvements:**

* Implemented the `deleteById` method in `InventoryItemImp` with comprehensive error handling: checks for existence, logs actions, and throws appropriate exceptions for not found, data integrity issues, and unexpected errors.