### PR TITLE
Feature/consume uom service using discovery service

### DIFF
--- a/src/main/java/com/elara/app/inventory_service/config/AppConfig.java
+++ b/src/main/java/com/elara/app/inventory_service/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.elara.app.inventory_service.config;
 
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -7,6 +8,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class AppConfig {
     @Bean
+    @LoadBalanced
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }

--- a/src/main/java/com/elara/app/inventory_service/service/imp/UomServiceClient.java
+++ b/src/main/java/com/elara/app/inventory_service/service/imp/UomServiceClient.java
@@ -4,6 +4,7 @@ import com.elara.app.inventory_service.dto.response.UomResponse;
 import com.elara.app.inventory_service.exceptions.ResourceNotFoundException;
 import com.elara.app.inventory_service.utils.MessageService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
@@ -15,8 +16,11 @@ public class UomServiceClient {
     private static final String NOMENCLATURE = "Uom-service";
     private static final String ENTITY_NAME = "Uom";
     private final RestTemplate restTemplate;
-    private final String uomServiceBaseUrl = "http://localhost:8080/api/v1/uom/";
     private final MessageService messageService;
+
+    //    New variables
+    @Value("${uom.service.name:unit-of-measure-service}")
+    private String uomServiceName;
 
     public UomServiceClient(RestTemplate restTemplate, MessageService messageService) {
         this.restTemplate = restTemplate;
@@ -24,13 +28,16 @@ public class UomServiceClient {
     }
 
     public void verifyUomById(Long id) {
+        final String methodNomenclature = NOMENCLATURE + "-existsById";
+        final String url = "http://" + uomServiceName + "/api/v1/uom/{id}";
         try {
-            log.debug("[" + NOMENCLATURE + "-findById] Searching {} with id: {}", ENTITY_NAME, id);
-            restTemplate.getForObject(uomServiceBaseUrl + id, UomResponse.class);
-            log.debug("[Uom-service-findById] {}", messageService.getMessage("crud.read.success", ENTITY_NAME));
+            log.debug("[{}] Searching {} with id: {}", methodNomenclature, ENTITY_NAME, id);
+            restTemplate.getForObject(url, UomResponse.class, id);
+            String msg = messageService.getMessage("crud.read.success", ENTITY_NAME);
+            log.debug("[{}] {}", methodNomenclature, msg);
         } catch (HttpClientErrorException.NotFound e) {
             String msg = messageService.getMessage("crud.not.found", "UOM", "id", id.toString());
-            log.warn("[" + NOMENCLATURE + "-findById] {}", msg);
+            log.warn("[{}] {}", methodNomenclature, msg);
             throw new ResourceNotFoundException(new Object[]{ENTITY_NAME, "id", id.toString()});
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,7 @@ eureka:
   client:
     service-url:
       defaultZone: ${EUREKA_URL:} # Eureka server URL for service registration and discovery
+
+uom:
+  service:
+    name: unit-of-measure-service


### PR DESCRIPTION
This pull request improves service discovery and configuration for the `UomServiceClient` in the inventory service. The main enhancements are the introduction of dynamic service name configuration for the UoM service, usage of Spring Cloud LoadBalancer for REST calls, and updates to logging for better traceability.

**Service Discovery & Configuration**

* Added the `@LoadBalanced` annotation to the `RestTemplate` bean in `AppConfig.java` to enable client-side load balancing and service discovery for REST calls.
* Made the UoM service name configurable via the `application.yml` file, allowing the service to resolve the UoM endpoint dynamically instead of using a hardcoded URL. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR31-R34) [[2]](diffhunk://#diff-1641239cbd6eccd75cc68bdeecf87c25595bc881c93135d90acfa1d1f955040fL18-R40)

**Code Refactoring & Logging**

* Refactored `UomServiceClient` to use the configurable service name for building the UoM service URL, improving maintainability and flexibility.
* Enhanced logging in `UomServiceClient` for better clarity and consistency, including dynamic method nomenclature and success/failure messages.