### PR TITLE
Feature/config server setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-vault-config</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
 
 		<!-- Runtime dependencies -->
 		<dependency>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    import: vault://secret/inventory-service/dev
+  cloud:
+    vault:
+      uri: http://localhost:8200
+      authentication: TOKEN
+      token: 00000000-0000-0000-0000-000000000000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,39 +1,7 @@
 spring:
   application:
     name: inventory-service
-  datasource:
-    url: ${DB_URL:}
-    driver-class-name: org.postgresql.Driver
   config:
-    import: vault://secret/inventory-service/dev
-  cloud:
-    vault:
-      uri: http://localhost:8200
-      authentication: TOKEN
-      token: 00000000-0000-0000-0000-000000000000
-  jpa:
-    hibernate:
-      ddl-auto: update
-#    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-server:
-  port: 0 # Use 0 to let Spring Boot assign a random available port at startup (useful for testing, avoiding port conflicts, or running multiple instances)
-eureka:
-  instance:
-    instance-id: ${spring.application.name}:${random.uuid} # Unique identifier for this service instance in Eureka
-    lease-expiration-duration-in-seconds: 90 # Time (seconds) Eureka waits before removing an instance if no heartbeat is received
-    lease-renewal-interval-in-seconds: 30 # Interval (seconds) for sending heartbeats to Eureka to renew registration
-    prefer-ip-address: true # Register service using IP address instead of hostname
-    metadata-map:
-      version: 1.0.0 # Custom metadata: service version
-      environment: production # Custom metadata: environment (e.g., production, staging)
-      region: us-east # Custom metadata: region/location of the service
-  client:
-    service-url:
-      defaultZone: ${EUREKA_URL:} # Eureka server URL for service registration and discovery
-
-uom:
-  service:
-    name: unit-of-measure-service
+    import: configserver:http://localhost:8888
+  profiles:
+    active: dev


### PR DESCRIPTION
This pull request introduces changes to the configuration management for the `inventory-service` by switching from direct Vault integration in the main configuration to using a centralized Spring Cloud Config Server. The configuration for Vault is now isolated to the development profile, and a new dependency is added to support Spring Cloud Config Server integration.

**Configuration Management Updates:**

* The main configuration file `application.yml` now imports configuration from a Spring Cloud Config Server (`configserver:http://localhost:8888`), and sets the active profile to `dev`. All direct Vault and database configurations have been removed from this file.
* The development profile configuration file `application-dev.yml` now imports secrets from Vault and sets Vault connection details, isolating Vault usage to the dev environment.

**Dependency Updates:**

* Added the `spring-cloud-starter-config` dependency in `pom.xml` to enable integration with Spring Cloud Config Server.