### PR TITLE
feat(dependencies): add spring-cloud-starter-bus-amqp for message bro…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
 		</dependency>
+		<dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bus-amqp</artifactId>
+        </dependency>
 
 		<!-- Runtime dependencies -->
 		<dependency>


### PR DESCRIPTION
This pull request adds a new dependency to the `pom.xml` file to enable Spring Cloud Bus AMQP support. This change will allow the application to propagate configuration changes across distributed services using AMQP messaging.

Dependency update:

* Added `spring-cloud-starter-bus-amqp` as a dependency to enable distributed configuration refresh using Spring Cloud Bus and AMQP.