### PR TITLE
Add DeepWiki Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/elara-app/inventory-service)
+
 # Inventory Service
 
 Spring Boot microservice for inventory item lifecycle and stock-relevant master data management within a distributed platform.


### PR DESCRIPTION
This pull request adds a DeepWiki badge to the `README.md` file, providing a quick link to documentation for the Inventory Service.